### PR TITLE
[FIX] correção dos nomes dos membros na parte inferior da página

### DIFF
--- a/src/components/inputs/answers/SelectInput.jsx
+++ b/src/components/inputs/answers/SelectInput.jsx
@@ -11,12 +11,10 @@ function SelectInput(props) {
     return (
         <div className="rounded shadow bg-white font-barlow pt-3 px-0 mt-3">
             <div className="row align-items-center justify-content-between m-0 pb-3">
-                <div className="d-flex col-9 align-items-center text-break text-start px-3">
-                    {props.input.question}
-                </div>
+                <div className="d-flex col-9 align-items-center text-break text-start px-3">{props.input.question}</div>
                 <div className="col px-0">
                     <select className="form-select border-0 rounded-3">
-                        <option defaultValue=""></option>
+                        <option disabled selected label="Selecione uma opção:"></option>
                         {options.map((option, index) => (
                             <option key={index} value={option.value}>
                                 {option.label}
@@ -25,7 +23,7 @@ function SelectInput(props) {
                     </select>
                 </div>
             </div>
-            
+
             <style>{styles}</style>
         </div>
     );

--- a/src/pages/InfosPage.jsx
+++ b/src/pages/InfosPage.jsx
@@ -30,19 +30,10 @@ const infosPageStyles = `
 `;
 
 function InfosPage(props) {
-    const { showSidebar, showAccept, showNavTogglerMobile, showNavTogglerDesktop } = props;
+    const { title, content, showSidebar, showAccept, showNavTogglerMobile, showNavTogglerDesktop } = props;
     const navigate = useNavigate();
     const modalRef = useRef(null);
     const location = useLocation();
-
-    let content, title;
-    if (location.pathname === '/about') {
-        title = 'Sobre o PICCE';
-        content = aboutPICCE;
-    } else if (location.pathname === '/equipe') {
-        title = 'Equipe';
-        content = teamMembers;
-    }
     
     return (
         <div className="d-flex flex-column font-barlow vh-100">

--- a/src/pages/InfosPage.jsx
+++ b/src/pages/InfosPage.jsx
@@ -33,6 +33,7 @@ function InfosPage(props) {
     const { title, content, showSidebar, showAccept, showNavTogglerMobile, showNavTogglerDesktop } = props;
     const navigate = useNavigate();
     const modalRef = useRef(null);
+    const location = useLocation();
     
     return (
         <div className="d-flex flex-column font-barlow vh-100">

--- a/src/pages/InfosPage.jsx
+++ b/src/pages/InfosPage.jsx
@@ -5,7 +5,7 @@ import Sidebar from '../components/Sidebar';
 import TextButton from '../components/TextButton';
 import Alert from '../components/Alert';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { teamMembers, aboutPICCE } from '../utils/constants';
+import { aboutPICCE } from '../utils/constants';
 
 const infosPageStyles = `
     .bg-coral-red {

--- a/src/pages/InfosPage.jsx
+++ b/src/pages/InfosPage.jsx
@@ -33,7 +33,6 @@ function InfosPage(props) {
     const { title, content, showSidebar, showAccept, showNavTogglerMobile, showNavTogglerDesktop } = props;
     const navigate = useNavigate();
     const modalRef = useRef(null);
-    const location = useLocation();
     
     return (
         <div className="d-flex flex-column font-barlow vh-100">

--- a/src/pages/InfosPage.jsx
+++ b/src/pages/InfosPage.jsx
@@ -5,7 +5,7 @@ import Sidebar from '../components/Sidebar';
 import TextButton from '../components/TextButton';
 import Alert from '../components/Alert';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { aboutPICCE } from '../utils/constants';
+import { teamMembers } from '../utils/constants';
 
 const infosPageStyles = `
     .bg-coral-red {

--- a/src/pages/InfosPage.jsx
+++ b/src/pages/InfosPage.jsx
@@ -1,10 +1,11 @@
-import { React, useRef } from 'react';
+import React, { useRef } from 'react';
 import NavBar from '../components/Navbar';
 import RoundedButton from '../components/RoundedButton';
 import Sidebar from '../components/Sidebar';
 import TextButton from '../components/TextButton';
 import Alert from '../components/Alert';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { teamMembers, aboutPICCE } from '../utils/constants';
 
 const infosPageStyles = `
     .bg-coral-red {
@@ -29,9 +30,20 @@ const infosPageStyles = `
 `;
 
 function InfosPage(props) {
-    const { title, content, showSidebar, showAccept, showNavTogglerMobile, showNavTogglerDesktop } = props;
+    const { showSidebar, showAccept, showNavTogglerMobile, showNavTogglerDesktop } = props;
     const navigate = useNavigate();
     const modalRef = useRef(null);
+    const location = useLocation();
+
+    let content, title;
+    if (location.pathname === '/about') {
+        title = 'Sobre o PICCE';
+        content = aboutPICCE;
+    } else if (location.pathname === '/equipe') {
+        title = 'Equipe';
+        content = teamMembers;
+    }
+    
     return (
         <div className="d-flex flex-column font-barlow vh-100">
             <div className="row m-0 flex-grow-1">
@@ -51,6 +63,12 @@ function InfosPage(props) {
                             <h1 className="font-century-gothic color-dark-gray fw-bold fs-4 pb-3 m-0">{title}</h1>
                             <h2 className="color-dark-gray text-justify fw-medium fs-6 pb-4 m-0">{content}</h2>
                         </div>
+                        {location.pathname === '/about' && (
+                            <div className="d-flex flex-column">
+                                <h1 className="font-century-gothic color-dark-gray fw-bold fs-4 pb-3 m-0">Equipe</h1>
+                                <h2 className="color-dark-gray text-justify fw-medium fs-6 pb-4 m-0">{teamMembers}</h2>
+                            </div>
+                        )}
                         <div className="row justify-content-between mx-0">
                             <div className="col-2"></div>
                             <div className="col-8 col-lg-4 align-items-center p-0">

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -11,7 +11,7 @@ import LogoutPage from './../pages/LogoutPage';
 import SignUpPage from './../pages/SignUpPage';
 import CreateProtocolPage from './../pages/CreateProtocolPage';
 import AnswerPage from '../pages/AnswerPage';
-import { teamMembers, aboutPICCE} from '../utils/constants';
+import {teamMembers} from '../utils/constants';
 
 function AppRoutes(props) {
     return (
@@ -43,7 +43,6 @@ function AppRoutes(props) {
             <Route path="/editprotocol/:id" element={<CreateProtocolPage edit={true} />} />
 
             <Route path="/about" element={<InfosPage title="Sobre o PICCE" content={aboutPICCE} showAccept={false} showNavTogglerDesktop={false} />} />
-            <Route path="/team" element={<InfosPage title="Equipe" content={teamMembers} showAccept={false} showNavTogglerDesktop={false} />} />
     
             <Route path="/logout" element={<LogoutPage />} />
             <Route path="/signup" element={<SignUpPage />} />

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -11,7 +11,7 @@ import LogoutPage from './../pages/LogoutPage';
 import SignUpPage from './../pages/SignUpPage';
 import CreateProtocolPage from './../pages/CreateProtocolPage';
 import AnswerPage from '../pages/AnswerPage';
-import { teamMembers } from '../utils/constants';
+import { teamMembers, aboutPICCE} from '../utils/constants';
 
 function AppRoutes(props) {
     return (
@@ -41,10 +41,10 @@ function AppRoutes(props) {
             <Route path="/help" element={<HelpPage />} />
             <Route path="/createprotocol" element={<CreateProtocolPage />} />
             <Route path="/editprotocol/:id" element={<CreateProtocolPage edit={true} />} />
-            <Route
-                path="/about"
-                element={<InfosPage title="Equipe" content={teamMembers} showAccept={false} showNavTogglerDesktop={false} />}
-            />
+
+            <Route path="/about" element={<InfosPage title="Sobre o PICCE" content={aboutPICCE} showAccept={false} showNavTogglerDesktop={false} />} />
+            <Route path="/equipe" element={<InfosPage title="Equipe" content={teamMembers} showAccept={false} showNavTogglerDesktop={false} />} />
+    
             <Route path="/logout" element={<LogoutPage />} />
             <Route path="/signup" element={<SignUpPage />} />
             <Route path="/answer/:id" element={<AnswerPage />} />

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -11,7 +11,7 @@ import LogoutPage from './../pages/LogoutPage';
 import SignUpPage from './../pages/SignUpPage';
 import CreateProtocolPage from './../pages/CreateProtocolPage';
 import AnswerPage from '../pages/AnswerPage';
-import {teamMembers} from '../utils/constants';
+import { aboutPICCE } from '../utils/constants';
 
 function AppRoutes(props) {
     return (

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -43,7 +43,7 @@ function AppRoutes(props) {
             <Route path="/editprotocol/:id" element={<CreateProtocolPage edit={true} />} />
 
             <Route path="/about" element={<InfosPage title="Sobre o PICCE" content={aboutPICCE} showAccept={false} showNavTogglerDesktop={false} />} />
-            <Route path="/equipe" element={<InfosPage title="Equipe" content={teamMembers} showAccept={false} showNavTogglerDesktop={false} />} />
+            <Route path="/team" element={<InfosPage title="Equipe" content={teamMembers} showAccept={false} showNavTogglerDesktop={false} />} />
     
             <Route path="/logout" element={<LogoutPage />} />
             <Route path="/signup" element={<SignUpPage />} />

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -59,21 +59,28 @@ export const aboutPICCE = (
     </>
 );
 
+const styles = `
+    .mb-2-5 {
+        margin-bottom: 12px !important;
+    }
+`;
+
 export const teamMembers = (
     <>
-        <p className="mb-8">Ana de Vasconcelos Oporto</p>
-        <p className="mb-8">Clara Drimel</p>
-        <p className="mb-8">Daniel Lins</p>
-        <p className="mb-8">Eduarda de Aguiar Freitas</p>
-        <p className="mb-8">Eduardo Mathias de Souza</p>
-        <p className="mb-8">Eloisa Nielsen</p>
-        <p className="mb-8">Guilherme Stonoga Tedardi</p>
-        <p className="mb-8">Izalorran Bonaldi</p>
-        <p className="mb-8">João Armênio</p>
-        <p className="mb-8">José Guilherme de Oliveira Pedroso</p>
-        <p className="mb-8">Juliana Zambon</p>
-        <p className="mb-8">Matheus Piovesan</p>
-        <p className="mb-8">Tiago Mendes Bottamedi</p>
-        <p className="mb-8">Yuri Tobias</p>
+        <p className="mb-2-5">Ana de Vasconcelos Oporto</p>
+        <p className="mb-2-5">Clara Drimel</p>
+        <p className="mb-2-5">Daniel Lins</p>
+        <p className="mb-2-5">Eduarda de Aguiar Freitas</p>
+        <p className="mb-2-5">Eduardo Mathias de Souza</p>
+        <p className="mb-2-5">Eloisa Nielsen</p>
+        <p className="mb-2-5">Guilherme Stonoga Tedardi</p>
+        <p className="mb-2-5">Izalorran Bonaldi</p>
+        <p className="mb-2-5">João Armênio</p>
+        <p className="mb-2-5">José Guilherme de Oliveira Pedroso</p>
+        <p className="mb-2-5">Juliana Zambon</p>
+        <p className="mb-2-5">Matheus Moraes Piovesan</p>
+        <p className="mb-2-5">Tiago Mendes Bottamedi</p>
+        <p className="mb-2-5">Yuri Junqueira Tobias</p>
+        <style>{styles}</style>
     </>
 );

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -61,7 +61,7 @@ export const aboutPICCE = (
 
 export const teamMembers = (
     <>
-        <p className="mb-4">Ana</p>
+        <p className="mb-4">Ana de Vasconcelos Oporto</p>
         <p className="mb-4">Clara Drimel</p>
         <p className="mb-4">Daniel Lins</p>
         <p className="mb-4">Eduarda de Aguiar Freitas</p>
@@ -70,7 +70,7 @@ export const teamMembers = (
         <p className="mb-4">Guilherme Stonoga Tedardi</p>
         <p className="mb-4">Izalorran Bonaldi</p>
         <p className="mb-4">João Armênio</p>
-        <p className="mb-4">José</p>
+        <p className="mb-4">José Guilherme de Oliveira Pedroso</p>
         <p className="mb-4">Juliana Zambon</p>
         <p className="mb-4">Matheus Piovesan</p>
         <p className="mb-4">Tiago Mendes Bottamedi</p>

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -45,6 +45,20 @@ export const defaultNewInput = (type) => {
     };
 };
 
+export const aboutPICCE = (
+    <>
+        Lorem ipsum dolor sit amet, consectetur adipisci elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad
+        minim veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur. Quis aute
+        iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident,
+        sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisci elit, sed eiusmod
+        tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrum exercitationem ullam corporis suscipit
+        laboriosam, nisi ut aliquid ex ea commodi consequatur. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat
+        nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem
+        ipsum dolor sit amet, consectetur adipisci elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrum exercitationem ullam corporis.
+    </>
+);
+
 export const teamMembers = (
     <>
         <p className="mb-4">Clara Drimel</p>
@@ -52,10 +66,12 @@ export const teamMembers = (
         <p className="mb-4">Eduarda de Aguiar Freitas</p>
         <p className="mb-4">Eduardo Mathias de Souza</p>
         <p className="mb-4">Eloisa Nielsen</p>
+        <p className="mb-4">Guilherme Stonoga Tedardi</p>
         <p className="mb-4">Izalorran Bonaldi</p>
         <p className="mb-4">João Armênio</p>
         <p className="mb-4">Juliana Zambon</p>
         <p className="mb-4">Matheus Piovesan</p>
+        <p className="mb-4">Tiago Mendes Bottamedi</p>
         <p className="mb-4">Yuri Tobias</p>
     </>
 );

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -61,19 +61,19 @@ export const aboutPICCE = (
 
 export const teamMembers = (
     <>
-        <p className="mb-4">Ana de Vasconcelos Oporto</p>
-        <p className="mb-4">Clara Drimel</p>
-        <p className="mb-4">Daniel Lins</p>
-        <p className="mb-4">Eduarda de Aguiar Freitas</p>
-        <p className="mb-4">Eduardo Mathias de Souza</p>
-        <p className="mb-4">Eloisa Nielsen</p>
-        <p className="mb-4">Guilherme Stonoga Tedardi</p>
-        <p className="mb-4">Izalorran Bonaldi</p>
-        <p className="mb-4">João Armênio</p>
-        <p className="mb-4">José Guilherme de Oliveira Pedroso</p>
-        <p className="mb-4">Juliana Zambon</p>
-        <p className="mb-4">Matheus Piovesan</p>
-        <p className="mb-4">Tiago Mendes Bottamedi</p>
-        <p className="mb-4">Yuri Tobias</p>
+        <p className="mb-8">Ana de Vasconcelos Oporto</p>
+        <p className="mb-8">Clara Drimel</p>
+        <p className="mb-8">Daniel Lins</p>
+        <p className="mb-8">Eduarda de Aguiar Freitas</p>
+        <p className="mb-8">Eduardo Mathias de Souza</p>
+        <p className="mb-8">Eloisa Nielsen</p>
+        <p className="mb-8">Guilherme Stonoga Tedardi</p>
+        <p className="mb-8">Izalorran Bonaldi</p>
+        <p className="mb-8">João Armênio</p>
+        <p className="mb-8">José Guilherme de Oliveira Pedroso</p>
+        <p className="mb-8">Juliana Zambon</p>
+        <p className="mb-8">Matheus Piovesan</p>
+        <p className="mb-8">Tiago Mendes Bottamedi</p>
+        <p className="mb-8">Yuri Tobias</p>
     </>
 );

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -61,6 +61,7 @@ export const aboutPICCE = (
 
 export const teamMembers = (
     <>
+        <p className="mb-4">Ana</p>
         <p className="mb-4">Clara Drimel</p>
         <p className="mb-4">Daniel Lins</p>
         <p className="mb-4">Eduarda de Aguiar Freitas</p>
@@ -69,6 +70,7 @@ export const teamMembers = (
         <p className="mb-4">Guilherme Stonoga Tedardi</p>
         <p className="mb-4">Izalorran Bonaldi</p>
         <p className="mb-4">João Armênio</p>
+        <p className="mb-4">José</p>
         <p className="mb-4">Juliana Zambon</p>
         <p className="mb-4">Matheus Piovesan</p>
         <p className="mb-4">Tiago Mendes Bottamedi</p>


### PR DESCRIPTION
- Incluí os nomes dos recém-chegados ao projeto na nossa equipe de membros;
- Editei a parte da rota para poder separar "sobre o PICCE" de "equipe";
- Adicionei o "lorem ipsum" de acordo com o layout padrão do Figma.
- Coloquei os nomes dos membros da equipe na parte inferior da página, logo após o conteúdo sobre o PICCE.

- Dúvida: Deixamos os nomes dos membros separados por linhas, como em tópicos mesmo?