### PR TITLE
#268 [FEAT]: Ampliação e restrições do suporte a Markdown

### DIFF
--- a/src/components/MarkdownText.jsx
+++ b/src/components/MarkdownText.jsx
@@ -1,0 +1,77 @@
+import Markdown from 'markdown-to-jsx';
+
+const MarkdownStyles = `
+    .font-barlow {
+        font-family: 'Barlow', sans-serif;
+    }
+
+    .bg-grey {
+        background-color: #D9D9D9
+    }
+
+    .color-dark-gray {
+        color: #535353;
+    }
+
+    .img-markdown {
+        max-width: 100%;
+        height: auto;
+    }
+`;
+
+function MarkdownText(props) {
+    const { text } = props;
+    return (
+        <>
+            <Markdown
+                options={{
+                    wrapper: 'div',
+                    forceWrapper: true,
+                    overrides: {
+                        img: {
+                            props: {
+                                className: 'img-markdown',
+                            },
+                        },
+                        h6: {
+                            props: {
+                                className: 'fw-bold fs-5 mb-3',
+                            },
+                        },
+                        h5: {
+                            props: {
+                                className: 'fw-bold fs-5 mb-3',
+                            },
+                        },
+                        h4: {
+                            props: {
+                                className: 'fw-bold fs-5 mb-3',
+                            },
+                        },
+                        h3: {
+                            props: {
+                                className: 'fw-bold fs-5 mb-3',
+                            },
+                        },
+                        h2: {
+                            props: {
+                                className: 'fw-bold fs-5 mb-3',
+                            },
+                        },
+                        h1: {
+                            props: {
+                                className: 'fw-bold fs-5 mb-3',
+                            },
+                        },
+                    },
+                }}
+                className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
+            >
+                {text}
+            </Markdown>
+            <style>{MarkdownStyles}</style>
+        </>
+    );
+}
+
+export default MarkdownText;

--- a/src/components/MarkdownText.jsx
+++ b/src/components/MarkdownText.jsx
@@ -27,10 +27,11 @@ function MarkdownText(props) {
                 options={{
                     wrapper: 'div',
                     forceWrapper: true,
+                    forceBlock: true,
                     overrides: {
                         img: {
                             props: {
-                                className: 'img-markdown',
+                                className: 'w-100 rounded-4',
                             },
                         },
                         h6: {

--- a/src/components/MarkdownText.jsx
+++ b/src/components/MarkdownText.jsx
@@ -12,11 +12,6 @@ const MarkdownStyles = `
     .color-dark-gray {
         color: #535353;
     }
-
-    .img-markdown {
-        max-width: 100%;
-        height: auto;
-    }
 `;
 
 function MarkdownText(props) {

--- a/src/components/ProtocolInfo.jsx
+++ b/src/components/ProtocolInfo.jsx
@@ -17,11 +17,6 @@ const protocolInfoStyles = `
     .bg-coral-red{
         background-color: #F59489;
     }
-
-    .img-markdown {
-        max-width: 100%;
-        height: auto;
-    }
 `;
 
 function ProtocolInfo(props) {

--- a/src/components/ProtocolInfo.jsx
+++ b/src/components/ProtocolInfo.jsx
@@ -30,8 +30,8 @@ function ProtocolInfo(props) {
     return (
         <div className="rounded-4 shadow bg-white overflow-hidden w-100 p-0">
             <div className="w-100 pb-3 bg-coral-red"></div>
-            <div className="p-3 pt-2">
-                <h1 className="color-dark-gray font-barlow text-break fw-bold fs-5 m-0 p-0 pb-2">{title}</h1>
+            <div className="p-3 pb-0">
+                <h1 className="color-dark-gray font-barlow text-break fw-bold fs-5 m-0 p-0 mb-3">{title}</h1>
                 <MarkdownText text={description} />
             </div>
 

--- a/src/components/ProtocolInfo.jsx
+++ b/src/components/ProtocolInfo.jsx
@@ -1,5 +1,5 @@
 import { React } from 'react';
-import Markdown from 'markdown-to-jsx';
+import MarkdownText from './MarkdownText';
 
 const protocolInfoStyles = `
     .font-barlow {
@@ -32,20 +32,7 @@ function ProtocolInfo(props) {
             <div className="w-100 pb-3 bg-coral-red"></div>
             <div className="p-3 pt-2">
                 <h1 className="color-dark-gray font-barlow text-break fw-bold fs-5 m-0 p-0 pb-2">{title}</h1>
-                <Markdown
-                    options={{
-                        overrides: {
-                            img: {
-                                props: {
-                                    className: 'img-markdown',
-                                },
-                            },
-                        },
-                    }}
-                    className="color-gray font-barlow text-break fw-medium fs-6 lh-sm m-0 p-0"
-                >
-                    {description}
-                </Markdown>
+                <MarkdownText text={description} />
             </div>
 
             <style>{protocolInfoStyles}</style>

--- a/src/components/inputs/answers/CheckBoxInput.jsx
+++ b/src/components/inputs/answers/CheckBoxInput.jsx
@@ -1,6 +1,6 @@
 import { React, useEffect, useState } from 'react';
 import TextButton from '../../TextButton';
-import Markdown from 'markdown-to-jsx';
+import MarkdownText from '../../MarkdownText';
 
 const styles = `
     .font-barlow {
@@ -13,11 +13,6 @@ const styles = `
 
     .color-dark-gray {
         color: #535353;
-    }
-
-    .img-markdown {
-        max-width: 100%;
-        height: auto;
     }
 `;
 
@@ -49,20 +44,7 @@ function CheckBoxInput(props) {
     return (
         <div className="rounded-4 shadow bg-white p-3">
             <div className="row m-0">
-                <Markdown
-                    options={{
-                        overrides: {
-                            img: {
-                                props: {
-                                    className: 'img-markdown',
-                                },
-                            },
-                        },
-                    }}
-                    className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
-                >
-                    {item.text}
-                </Markdown>
+                <MarkdownText text={item.text} />
             </div>
 
             {item.files.length > 0 && galleryRef && (

--- a/src/components/inputs/answers/CheckBoxInput.jsx
+++ b/src/components/inputs/answers/CheckBoxInput.jsx
@@ -1,5 +1,6 @@
 import { React, useEffect, useState } from 'react';
 import TextButton from '../../TextButton';
+import Markdown from 'markdown-to-jsx';
 
 const styles = `
     .font-barlow {
@@ -12,6 +13,11 @@ const styles = `
 
     .color-dark-gray {
         color: #535353;
+    }
+
+    .img-markdown {
+        max-width: 100%;
+        height: auto;
     }
 `;
 
@@ -43,7 +49,20 @@ function CheckBoxInput(props) {
     return (
         <div className="rounded-4 shadow bg-white p-3">
             <div className="row m-0">
-                <p className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0">{item.text}</p>
+                <Markdown
+                    options={{
+                        overrides: {
+                            img: {
+                                props: {
+                                    className: 'img-markdown',
+                                },
+                            },
+                        },
+                    }}
+                    className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
+                >
+                    {item.text}
+                </Markdown>
             </div>
 
             {item.files.length > 0 && galleryRef && (

--- a/src/components/inputs/answers/CheckBoxInput.jsx
+++ b/src/components/inputs/answers/CheckBoxInput.jsx
@@ -48,7 +48,7 @@ function CheckBoxInput(props) {
             </div>
 
             {item.files.length > 0 && galleryRef && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0 mb-3">
                     {item.files.slice(0, ImageVisibility ? item.files.length : 3).map((image, index) => {
                         return (
                             <div
@@ -72,7 +72,7 @@ function CheckBoxInput(props) {
             )}
 
             {item.files.length > 3 && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0 mb-3">
                     <TextButton
                         className="fs-6 w-auto p-2 py-0"
                         hsl={[190, 46, 70]}
@@ -82,7 +82,7 @@ function CheckBoxInput(props) {
                 </div>
             )}
 
-            <div className="row m-0 pt-3 px-2">
+            <div className="row m-0 px-2">
                 {item.itemOptions.map((option) => {
                     const optname = option.text.toLowerCase().replace(/\s/g, '');
 

--- a/src/components/inputs/answers/ImageInput.jsx
+++ b/src/components/inputs/answers/ImageInput.jsx
@@ -61,7 +61,7 @@ function ImageInput(props) {
             <form className="d-flex flex-column flex-grow-1">
                 <div className="row rounded p-0 pb-3 m-0">
                     <MarkdownText text={item.text} />
-                    <div className="d-flex align-items-center mt-3 p-0">
+                    <div className="d-flex align-items-center p-0">
                         <RoundedButton
                             hsl={[190, 46, 70]}
                             icon={iconFile}

--- a/src/components/inputs/answers/ImageInput.jsx
+++ b/src/components/inputs/answers/ImageInput.jsx
@@ -15,11 +15,6 @@ const styles = `
     .font-barlow {
         font-family: 'Barlow', sans-serif;
     }
-
-    .img-markdown {
-        max-width: 100%;
-        height: auto;
-    }
 `;
 
 function ImageInput(props) {

--- a/src/components/inputs/answers/ImageInput.jsx
+++ b/src/components/inputs/answers/ImageInput.jsx
@@ -5,6 +5,7 @@ import RoundedButton from '../../RoundedButton';
 import iconFile from '../../../assets/images/iconFile.svg';
 import eyeIcon from '../../../assets/images/eyeIcon.svg';
 import iconTrash from '../../../assets/images/iconTrash.svg';
+import Markdown from 'markdown-to-jsx';
 
 const styles = `
     .color-dark-gray {
@@ -13,6 +14,11 @@ const styles = `
 
     .font-barlow {
         font-family: 'Barlow', sans-serif;
+    }
+
+    .img-markdown {
+        max-width: 100%;
+        height: auto;
     }
 `;
 
@@ -54,10 +60,21 @@ function ImageInput(props) {
         <div className="rounded-4 shadow bg-white w-100 p-3">
             <form className="d-flex flex-column flex-grow-1">
                 <div className="row rounded p-0 pb-3 m-0">
-                    <label htmlFor="imageinput" className="control-label color-dark-gray font-barlow fw-medium fs-6 p-0 pb-3">
+                    <Markdown
+                        options={{
+                            overrides: {
+                                img: {
+                                    props: {
+                                        className: 'img-markdown',
+                                    },
+                                },
+                            },
+                        }}
+                        className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
+                    >
                         {item.text}
-                    </label>
-                    <div className="d-flex align-items-center p-0">
+                    </Markdown>
+                    <div className="d-flex align-items-center mt-3 p-0">
                         <RoundedButton
                             hsl={[190, 46, 70]}
                             icon={iconFile}

--- a/src/components/inputs/answers/ImageInput.jsx
+++ b/src/components/inputs/answers/ImageInput.jsx
@@ -5,7 +5,7 @@ import RoundedButton from '../../RoundedButton';
 import iconFile from '../../../assets/images/iconFile.svg';
 import eyeIcon from '../../../assets/images/eyeIcon.svg';
 import iconTrash from '../../../assets/images/iconTrash.svg';
-import Markdown from 'markdown-to-jsx';
+import MarkdownText from '../../MarkdownText';
 
 const styles = `
     .color-dark-gray {
@@ -60,20 +60,7 @@ function ImageInput(props) {
         <div className="rounded-4 shadow bg-white w-100 p-3">
             <form className="d-flex flex-column flex-grow-1">
                 <div className="row rounded p-0 pb-3 m-0">
-                    <Markdown
-                        options={{
-                            overrides: {
-                                img: {
-                                    props: {
-                                        className: 'img-markdown',
-                                    },
-                                },
-                            },
-                        }}
-                        className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
-                    >
-                        {item.text}
-                    </Markdown>
+                    <MarkdownText text={item.text} />
                     <div className="d-flex align-items-center mt-3 p-0">
                         <RoundedButton
                             hsl={[190, 46, 70]}

--- a/src/components/inputs/answers/RadioButtonInput.jsx
+++ b/src/components/inputs/answers/RadioButtonInput.jsx
@@ -1,5 +1,6 @@
 import { React, useEffect, useState } from 'react';
 import TextButton from '../../TextButton';
+import Markdown from 'markdown-to-jsx';
 
 const styles = `
     .font-barlow {
@@ -12,6 +13,11 @@ const styles = `
 
     .color-dark-gray {
         color: #535353;
+    }
+
+    .img-markdown {
+        max-width: 100%;
+        height: auto;
     }
 `;
 
@@ -39,7 +45,20 @@ function RadioButtonInput(props) {
     return (
         <div className="rounded-4 shadow bg-white p-3">
             <div className="row m-0">
-                <p className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0">{item.text}</p>
+                <Markdown
+                    options={{
+                        overrides: {
+                            img: {
+                                props: {
+                                    className: 'img-markdown',
+                                },
+                            },
+                        },
+                    }}
+                    className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
+                >
+                    {item.text}
+                </Markdown>
             </div>
 
             {item.files.length > 0 && galleryRef && (

--- a/src/components/inputs/answers/RadioButtonInput.jsx
+++ b/src/components/inputs/answers/RadioButtonInput.jsx
@@ -1,6 +1,6 @@
 import { React, useEffect, useState } from 'react';
 import TextButton from '../../TextButton';
-import Markdown from 'markdown-to-jsx';
+import MarkdownText from '../../MarkdownText';
 
 const styles = `
     .font-barlow {
@@ -45,20 +45,7 @@ function RadioButtonInput(props) {
     return (
         <div className="rounded-4 shadow bg-white p-3">
             <div className="row m-0">
-                <Markdown
-                    options={{
-                        overrides: {
-                            img: {
-                                props: {
-                                    className: 'img-markdown',
-                                },
-                            },
-                        },
-                    }}
-                    className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
-                >
-                    {item.text}
-                </Markdown>
+                <MarkdownText text={item.text} />
             </div>
 
             {item.files.length > 0 && galleryRef && (

--- a/src/components/inputs/answers/RadioButtonInput.jsx
+++ b/src/components/inputs/answers/RadioButtonInput.jsx
@@ -49,7 +49,7 @@ function RadioButtonInput(props) {
             </div>
 
             {item.files.length > 0 && galleryRef && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0 mb-3">
                     {item.files.slice(0, ImageVisibility ? item.files.length : 3).map((image, index) => {
                         return (
                             <div
@@ -73,7 +73,7 @@ function RadioButtonInput(props) {
             )}
 
             {item.files.length > 3 && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0 mb-3">
                     <TextButton
                         className="fs-6 w-auto p-2 py-0"
                         hsl={[190, 46, 70]}
@@ -83,7 +83,7 @@ function RadioButtonInput(props) {
                 </div>
             )}
 
-            <div className="row m-0 pt-3 px-2">
+            <div className="row m-0 px-2">
                 {item.itemOptions.map((option) => {
                     const optname = option.text.toLowerCase().replace(/\s/g, '');
                     return (

--- a/src/components/inputs/answers/RadioButtonInput.jsx
+++ b/src/components/inputs/answers/RadioButtonInput.jsx
@@ -14,11 +14,6 @@ const styles = `
     .color-dark-gray {
         color: #535353;
     }
-
-    .img-markdown {
-        max-width: 100%;
-        height: auto;
-    }
 `;
 
 function RadioButtonInput(props) {

--- a/src/components/inputs/answers/SimpleTextInput.jsx
+++ b/src/components/inputs/answers/SimpleTextInput.jsx
@@ -1,6 +1,6 @@
 import { React, useEffect, useState } from 'react';
 import TextButton from '../../TextButton';
-import Markdown from 'markdown-to-jsx';
+import MarkdownText from '../../MarkdownText';
 
 const styles = `
     .font-barlow {
@@ -42,20 +42,7 @@ function SimpleTextInput(props) {
     return (
         <div className="rounded-4 shadow bg-white p-3">
             <div className="row m-0">
-                <Markdown
-                    options={{
-                        overrides: {
-                            img: {
-                                props: {
-                                    className: 'img-markdown',
-                                },
-                            },
-                        },
-                    }}
-                    className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
-                >
-                    {item.text}
-                </Markdown>
+                <MarkdownText text={item.text} />
             </div>
 
             {item.files.length > 0 && galleryRef && (

--- a/src/components/inputs/answers/SimpleTextInput.jsx
+++ b/src/components/inputs/answers/SimpleTextInput.jsx
@@ -19,11 +19,6 @@ const styles = `
         border: 0px;
         border-bottom: 1px solid #C1C1C1;
     }
-
-    .img-markdown {
-        max-width: 100%;
-        height: auto;
-    }
 `;
 
 function SimpleTextInput(props) {

--- a/src/components/inputs/answers/SimpleTextInput.jsx
+++ b/src/components/inputs/answers/SimpleTextInput.jsx
@@ -46,7 +46,7 @@ function SimpleTextInput(props) {
             </div>
 
             {item.files.length > 0 && galleryRef && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0 mb-3">
                     {item.files.slice(0, ImageVisibility ? item.files.length : 3).map((image, index) => {
                         return (
                             <div
@@ -70,7 +70,7 @@ function SimpleTextInput(props) {
             )}
 
             {item.files.length > 3 && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0 mb-3">
                     <TextButton
                         className="fs-6 w-auto p-2 py-0"
                         hsl={[190, 46, 70]}
@@ -82,7 +82,7 @@ function SimpleTextInput(props) {
 
             <input
                 type="text"
-                className="simple-text-input form-control rounded-0 shadow-none bg-dark-grey font-barlow fw-medium fs-6 mb-3 pt-3 p-0"
+                className="simple-text-input form-control rounded-0 shadow-none bg-dark-grey font-barlow fw-medium fs-6 mb-3 p-0"
                 id="simpletextinput"
                 placeholder="Digite sua resposta aqui"
                 onChange={(e) => setText(e.target.value)}

--- a/src/components/inputs/answers/SimpleTextInput.jsx
+++ b/src/components/inputs/answers/SimpleTextInput.jsx
@@ -1,5 +1,6 @@
 import { React, useEffect, useState } from 'react';
 import TextButton from '../../TextButton';
+import Markdown from 'markdown-to-jsx';
 
 const styles = `
     .font-barlow {
@@ -17,6 +18,11 @@ const styles = `
     .simple-text-input {
         border: 0px;
         border-bottom: 1px solid #C1C1C1;
+    }
+
+    .img-markdown {
+        max-width: 100%;
+        height: auto;
     }
 `;
 
@@ -36,9 +42,20 @@ function SimpleTextInput(props) {
     return (
         <div className="rounded-4 shadow bg-white p-3">
             <div className="row m-0">
-                <label htmlFor="simpletextinput" className="form-label color-dark-gray font-barlow fw-medium fs-6 m-0 p-0">
+                <Markdown
+                    options={{
+                        overrides: {
+                            img: {
+                                props: {
+                                    className: 'img-markdown',
+                                },
+                            },
+                        },
+                    }}
+                    className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
+                >
                     {item.text}
-                </label>
+                </Markdown>
             </div>
 
             {item.files.length > 0 && galleryRef && (

--- a/src/components/inputs/answers/TextImageInput.jsx
+++ b/src/components/inputs/answers/TextImageInput.jsx
@@ -70,11 +70,4 @@ function TextImageInput(props) {
     );
 }
 
-TextImageInput.defaultProps = {
-    input: {
-        question: 'Pergunta',
-        description: 'https://picsum.photos/1300/1300?random=1',
-    },
-};
-
 export default TextImageInput;

--- a/src/components/inputs/answers/TextImageInput.jsx
+++ b/src/components/inputs/answers/TextImageInput.jsx
@@ -25,13 +25,13 @@ function TextImageInput(props) {
     };
 
     return (
-        <div className="rounded-4 shadow bg-white p-3">
+        <div className="rounded-4 shadow bg-white p-3 pb-0">
             <div className="row m-0">
                 <MarkdownText text={item.text} />
             </div>
 
             {item.files.length > 0 && galleryRef && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0">
                     {item.files.slice(0, ImageVisibility ? item.files.length : 3).map((image, index) => {
                         return (
                             <div
@@ -55,7 +55,7 @@ function TextImageInput(props) {
             )}
 
             {item.files.length > 3 && (
-                <div className="row justify-content-center m-0 pt-3">
+                <div className="row justify-content-center m-0">
                     <TextButton
                         className="fs-6 w-auto p-2 py-0"
                         hsl={[190, 46, 70]}

--- a/src/components/inputs/answers/TextImageInput.jsx
+++ b/src/components/inputs/answers/TextImageInput.jsx
@@ -1,6 +1,6 @@
 import { React, useState } from 'react';
-import Markdown from 'markdown-to-jsx';
 import TextButton from '../../TextButton';
+import MarkdownText from '../../MarkdownText';
 
 const styles = `
     .font-barlow {
@@ -13,11 +13,6 @@ const styles = `
 
     .color-dark-gray {
         color: #535353;
-    }
-
-    .img-markdown {
-        max-width: 100%;
-        height: auto;
     }
 `;
 
@@ -32,20 +27,7 @@ function TextImageInput(props) {
     return (
         <div className="rounded-4 shadow bg-white p-3">
             <div className="row m-0">
-                <Markdown
-                    options={{
-                        overrides: {
-                            img: {
-                                props: {
-                                    className: 'img-markdown',
-                                },
-                            },
-                        },
-                    }}
-                    className="form-label color-dark-gray font-barlow fw-medium fs-6 lh-sm m-0 p-0"
-                >
-                    {item.text}
-                </Markdown>
+                <MarkdownText text={item.text} />
             </div>
 
             {item.files.length > 0 && galleryRef && (


### PR DESCRIPTION
**Funcionalidades adicionadas**
- Restrições em Markdown para melhorar integração visual: cores e fontes restringidas, parágrafos padronizados em tamanho único (h1, h2, h3, h4, h5 e h6), imagens com bordas arredondadas e preenchimento horizontal completo;
- Encapsulamento do componente MarkdownText para facilitar inserções múltiplas;
- Inserção do suporte a Markdown nos componentes ProtocolInfo, CheckBoxInput, RadioButtonInput, ImageInput, SimpleTextInput e TextImageInput (que continua não sendo um input);

**Comentários**
- Suporte a Markdown não adicionado no componente SelectInput vide o mesmo ter alterações pendentes e código despadronizado;
- Suporte não adicionado em DateInput, TimeInput e Location input vide não caber seu uso;
- Suporte não adicionado em Weather vide o componente estar defasado;