### PR TITLE
#445 [FEAT]: Botão de rolagem para o topo da página

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import { StorageProvider } from './contexts/StorageContext';
 import appRoutes from './routes/AppRoutes';
 import { AlertProvider } from './contexts/AlertContext';
 import 'react-material-symbols/rounded';
+import ScrollToTopButton from './components/ScrollToTopButton';
 
 const styles = ``;
 
@@ -28,6 +29,7 @@ function App(props) {
             <AuthProvider>
                 <AlertProvider>
                     <RouterProvider router={createBrowserRouter(appRoutes)} />
+                    <ScrollToTopButton />
                     <style> {styles} </style>
                 </AlertProvider>
             </AuthProvider>

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,0 +1,30 @@
+/*
+Copyright (C) 2024 Laboratorio Visao Robotica e Imagem
+
+Departamento de Informatica - Universidade Federal do Parana - VRI/UFPR
+
+This file is part of CienciaNaEscola. CienciaNaEscola is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+CienciaNaEscola is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a copy
+of the GNU General Public License along with CienciaNaEscola.  If not, see <https://www.gnu.org/licenses/>
+*/
+
+import { useState } from 'react';
+import RoundedButton from './RoundedButton';
+
+function ScrollToTopButton() {
+    const [windowScroll, setWindowScroll] = useState(window.scrollY);
+
+    window.onscroll = () => setWindowScroll(window.scrollY);
+
+    const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
+
+    return (
+        <div className={`${windowScroll > 20 ? 'd-flex' : 'd-none'} flex-column justify-content-end align-items-end fixed-bottom p-4`}>
+            <RoundedButton icon="stat_3" hsl={[197, 43, 52]} onClick={scrollToTop} />
+        </div>
+    );
+}
+
+export default ScrollToTopButton;


### PR DESCRIPTION
Esse pull request introduz um novo componente `ScrollToTopButton` no aplicativo e o integra ao componente principal `App`. As alterações mais importantes incluem a adição do novo componente e sua integração à estrutura existente do aplicativo.

Adição de novo componente:

* [`src/components/ScrollToTopButton.jsx`](diffhunk://#diff-2622c22bfb5db1d93edecdba9be3ceaddfc0bdc4e907914d3d89483fccb94edcR1-R30): Criado um novo componente `ScrollToTopButton` que aparece quando o usuário rola a tela para baixo e permite que ele role de volta para o topo sem problemas. Esse componente usa o componente `RoundedButton` e gerencia sua visibilidade com base na posição de rolagem.

Integração ao aplicativo principal:

* [`src/App.jsx`](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R22): Importado o componente `ScrollToTopButton` e adicionado ao método de renderização do componente `App`, garantindo que ele seja incluído no layout principal do aplicativo. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R22) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R32)