### PR TITLE
#514 [FIX]: Bloqueio da dashboard para usuários comuns e visitantes

### DIFF
--- a/src/contexts/LayoutContext.js
+++ b/src/contexts/LayoutContext.js
@@ -13,12 +13,15 @@ of the GNU General Public License along with CienciaNaEscola.  If not, see <http
 import { createContext, useContext, useEffect } from 'react';
 import { Outlet, useBlocker } from 'react-router-dom';
 import { AlertContext } from './AlertContext';
+import { AuthContext } from './AuthContext';
+import ErrorPage from '../pages/ErrorPage';
 
 export const LayoutContext = createContext();
 
 export const LayoutProvider = (props) => {
-    const { isDashboard } = props;
+    const { isDashboard = false } = props;
     const { hideAlert, isAlertVisible, isClosable } = useContext(AlertContext);
+    const { user } = useContext(AuthContext);
     const blocker = useBlocker(({ currentLocation, nextLocation }) => isAlertVisible && currentLocation.pathname !== nextLocation.pathname);
 
     useEffect(() => {
@@ -34,7 +37,11 @@ export const LayoutProvider = (props) => {
 
     return (
         <LayoutContext.Provider value={{ isDashboard }}>
-            <Outlet />
+            {isDashboard && (user.role === 'GUEST' || user.role === 'USER') ? (
+                <ErrorPage text={'Operação não permitida'} description={'Você não possui acesso às funções da dashboard'} />
+            ) : (
+                <Outlet />
+            )}
         </LayoutContext.Provider>
     );
 };


### PR DESCRIPTION
A função aqui apresentada tem por objetivo impedir que usuários não autorizados, i.e. com `roles` `GUEST` ou ` USER` acessem as rotas relacionadas à dashboard.

As alterações mais relevantes são apresentadas abaixo:

### Bloqueio da dashboard via LayoutContext
* Uma vez que `LayoutContext` possui acesso às informações de `AuthContext`, foi utilizado o cruzamento das propriedades `isDasboard` da primeira com `user.role` da segunda para garantir que o roteamento não ocorra caso `USERs` e `GUESTs` tentem acessar rotas atribuídas à dash [[1]](diffhunk://#diff-5807ea029ee3f1c1b984e54214a68a8f04efe45a26ba67e877a9023f7d5fe4f8R40-R44); 