### PR TITLE
#515 [FEAT]: Informações adicionais em listas de protocolos e aplicações

### DIFF
--- a/src/components/CreateItemGroup.jsx
+++ b/src/components/CreateItemGroup.jsx
@@ -193,7 +193,7 @@ function CreateItemGroup(props) {
                         hsl={[197, 43, 52]}
                         onClick={() => updateGroupPlacement(group.placement + 1, group.placement, itemTarget.group)}
                         icon="keyboard_arrow_down"
-                        className={`move-group-${group.tempId.toString().slice(0, 13)}-down-tooltip`}
+                        className={`move-group-${group.tempId.toString().slice(0, 13)}-down-tooltip text-white`}
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={`move-group-${group.tempId}-down-tooltip`}
                         data-bs-title="Mover o grupo uma posição abaixo na ordem dos grupos da página."
@@ -204,7 +204,7 @@ function CreateItemGroup(props) {
                         hsl={[197, 43, 52]}
                         onClick={() => updateGroupPlacement(group.placement - 1, group.placement, itemTarget.group)}
                         icon="keyboard_arrow_up"
-                        className={`move-group-${group.tempId.toString().slice(0, 13)}-up-tooltip`}
+                        className={`move-group-${group.tempId.toString().slice(0, 13)}-up-tooltip text-white`}
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={`move-group-${group.tempId}-up-tooltip`}
                         data-bs-title="Mover o grupo uma posição acima na ordem dos grupos da página."
@@ -215,7 +215,7 @@ function CreateItemGroup(props) {
                         hsl={[197, 43, 52]}
                         onClick={() => removeItemGroup(itemTarget.group)}
                         icon="delete"
-                        className={`delete-group-${group.tempId.toString().slice(0, 13)}-tooltip`}
+                        className={`delete-group-${group.tempId.toString().slice(0, 13)}-tooltip text-white`}
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={`delete-group-${group.tempId}-tooltip`}
                         data-bs-title="Remover o grupo da página."

--- a/src/components/CreatePage.jsx
+++ b/src/components/CreatePage.jsx
@@ -104,7 +104,7 @@ function CreatePage(props) {
                         hsl={[197, 43, 52]}
                         onClick={() => updatePagePlacement(page.placement + 1, page.placement, itemTarget.page)}
                         icon="keyboard_arrow_down"
-                        className={`move-page-${page.tempId.toString().slice(0, 13)}-down-tooltip`}
+                        className={`move-page-${page.tempId.toString().slice(0, 13)}-down-tooltip text-white`}
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={`move-page-${page.tempId}-down-tooltip`}
                         data-bs-title="Mover a página uma posição abaixo na ordem das páginas do protocolo."
@@ -115,7 +115,7 @@ function CreatePage(props) {
                         hsl={[197, 43, 52]}
                         onClick={() => updatePagePlacement(page.placement - 1, page.placement, itemTarget.page)}
                         icon="keyboard_arrow_up"
-                        className={`move-page-${page.tempId.toString().slice(0, 13)}-up-tooltip`}
+                        className={`move-page-${page.tempId.toString().slice(0, 13)}-up-tooltip text-white`}
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={`move-page-${page.tempId}-up-tooltip`}
                         data-bs-title="Mover a página uma posição acima na ordem das páginas do protocolo."
@@ -126,7 +126,7 @@ function CreatePage(props) {
                         hsl={[197, 43, 52]}
                         onClick={() => removePage(itemTarget.page)}
                         icon="delete"
-                        className={`delete-page-${page.tempId.toString().slice(0, 13)}-tooltip`}
+                        className={`delete-page-${page.tempId.toString().slice(0, 13)}-tooltip text-white`}
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={`delete-page-${page.tempId}-tooltip`}
                         data-bs-title="Remover a página do protocolo."

--- a/src/components/CreateProcotolProperties.jsx
+++ b/src/components/CreateProcotolProperties.jsx
@@ -350,6 +350,7 @@ function CreateProtocolProperties(props) {
                         <div className="col-auto">
                             <RoundedButton
                                 hsl={[197, 43, 52]}
+                                className="text-white"
                                 onClick={() => searchUsers(searchInputs.viewersUser, 'viewersUser')}
                                 icon="search"
                             />
@@ -415,6 +416,7 @@ function CreateProtocolProperties(props) {
                         <div className="col-auto">
                             <RoundedButton
                                 hsl={[197, 43, 52]}
+                                className="text-white"
                                 onClick={() => searchClassrooms(searchInputs.viewersClassroom, 'viewersClassroom')}
                                 icon="search"
                             />
@@ -503,6 +505,7 @@ function CreateProtocolProperties(props) {
                         <div className="col-auto">
                             <RoundedButton
                                 hsl={[197, 43, 52]}
+                                className="text-white"
                                 onClick={() => searchUsers(searchInputs.appliers, 'appliers')}
                                 icon="search"
                             />
@@ -598,6 +601,7 @@ function CreateProtocolProperties(props) {
                         <div className="col-auto">
                             <RoundedButton
                                 hsl={[197, 43, 52]}
+                                className="text-white"
                                 onClick={() => searchUsers(searchInputs.answersViewersUser, 'answersViewersUser')}
                                 icon="search"
                             />
@@ -662,6 +666,7 @@ function CreateProtocolProperties(props) {
                         <div className="col-auto">
                             <RoundedButton
                                 hsl={[197, 43, 52]}
+                                className="text-white"
                                 onClick={() => searchClassrooms(searchInputs.answersViewersClassroom, 'answersViewersClassroom')}
                                 icon="search"
                             />

--- a/src/components/GalleryModal.jsx
+++ b/src/components/GalleryModal.jsx
@@ -76,7 +76,7 @@ const GalleryModal = forwardRef((props, ref) => {
                         <h5 className="modal-title font-century-gothic color-dark-gray text-center fs-3 fw-bold">
                             Figura {modal.currentImage + 1}
                         </h5>
-                        <RoundedButton hsl={[355, 78, 66]} icon="close" onClick={hideModal} />
+                        <RoundedButton hsl={[355, 78, 66]} icon="close" onClick={hideModal} className="text-white" />
                     </div>
 
                     <div className="modal-body">

--- a/src/components/HomeButton.jsx
+++ b/src/components/HomeButton.jsx
@@ -46,6 +46,8 @@ const styles = `
 function HomeButton(props) {
     const {
         title,
+        primaryDescription,
+        secondaryDescription,
         viewFunction = () => {},
         allowEdit = false,
         editFunction = () => {},
@@ -56,43 +58,51 @@ function HomeButton(props) {
     const { showAlert } = useContext(AlertContext);
 
     return (
-        <div className="custom-btn rounded-4 row g-0 align-items-center font-barlow h-100 w-100 py-2 px-4" onClick={viewFunction}>
+        <div className="custom-btn rounded-4 row g-1 align-items-center font-barlow h-100 w-100 p-3" onClick={viewFunction}>
             <div className="col home-btn-title">
-                <h5 className="text-break fw-medium m-0">{title}</h5>
+                <h5 className="text-break fs-6 lh-1 fw-medium m-0">{title}</h5>
+                <p className="text-break fs-6 lh-1 fw-light m-0">{primaryDescription || ''}</p>
+                <p className="text-break fs-6 lh-1 fw-light m-0">{secondaryDescription || ''}</p>
             </div>
-            {allowEdit && (
-                <div className="col-auto ms-2">
-                    <RoundedButton
-                        hsl={[37, 98, 76]}
-                        size={35}
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            editFunction();
-                        }}
-                        icon="edit"
-                    />
+            <div className="col-auto">
+                <div className="row d-flex flex-column flex-lg-row g-1">
+                    <div className="col-12 col-lg-auto">
+                        {allowEdit && (
+                            <RoundedButton
+                                hsl={[37, 98, 76]}
+                                size={30}
+                                className="text-white"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    editFunction();
+                                }}
+                                icon="edit"
+                            />
+                        )}
+                    </div>
+                    <div className="col-12 col-lg-auto">
+                        {allowDelete && (
+                            <RoundedButton
+                                hsl={[355, 78, 66]}
+                                size={30}
+                                className="text-white"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    showAlert({
+                                        headerText: 'Tem certeza que deseja excluir?',
+                                        primaryBtnHsl: [355, 78, 66],
+                                        primaryBtnLabel: 'Não',
+                                        secondaryBtnHsl: [97, 43, 70],
+                                        secondaryBtnLabel: 'Sim',
+                                        onSecondaryBtnClick: () => deleteFunction(),
+                                    });
+                                }}
+                                icon="delete"
+                            />
+                        )}
+                    </div>
                 </div>
-            )}
-            {allowDelete && (
-                <div className="col-auto ms-2">
-                    <RoundedButton
-                        hsl={[355, 78, 66]}
-                        size={35}
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            showAlert({
-                                headerText: 'Tem certeza que deseja excluir?',
-                                primaryBtnHsl: [355, 78, 66],
-                                primaryBtnLabel: 'Não',
-                                secondaryBtnHsl: [97, 43, 70],
-                                secondaryBtnLabel: 'Sim',
-                                onSecondaryBtnClick: () => deleteFunction(),
-                            });
-                        }}
-                        icon="delete"
-                    />
-                </div>
-            )}
+            </div>
             {check && (
                 <div className="col-auto ms-2">
                     <img src={CheckIcon} alt="Ícone de já respondido" className="icon-check" />

--- a/src/components/HomeButton.jsx
+++ b/src/components/HomeButton.jsx
@@ -10,7 +10,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
 of the GNU General Public License along with CienciaNaEscola.  If not, see <https://www.gnu.org/licenses/>
 */
 
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import CheckIcon from '../assets/images/CheckIcon.svg';
 import RoundedButton from './RoundedButton';
 import { AlertContext } from '../contexts/AlertContext';
@@ -37,6 +37,12 @@ const styles = `
         width: 0px;
     }
 
+    .h-100px {
+        height: 100px;
+        min-heigth: 100px;
+        max-height: 100px;
+    }
+
     .icon-check{
         width: 35px;
         height: 35px;
@@ -55,10 +61,15 @@ function HomeButton(props) {
         deleteFunction = () => {},
         check = false,
     } = props;
+
     const { showAlert } = useContext(AlertContext);
+    const [isCollapsed, setIsCollapsed] = useState(true);
 
     return (
-        <div className="custom-btn rounded-4 row g-1 align-items-center font-barlow h-100 w-100 p-3" onClick={viewFunction}>
+        <div
+            className={`custom-btn rounded-4 row g-1 align-items-center font-barlow w-100 p-3 ${isCollapsed ? 'h-100px' : ''}`}
+            onClick={viewFunction}
+        >
             <div className="col home-btn-title">
                 <h5 className="text-break fs-6 lh-1 fw-medium m-0">{title}</h5>
                 <p className="text-break fs-6 lh-1 fw-light m-0">{primaryDescription || ''}</p>
@@ -67,7 +78,7 @@ function HomeButton(props) {
             <div className="col-auto">
                 <div className="row d-flex flex-column flex-lg-row g-1">
                     <div className="col-12 col-lg-auto">
-                        {allowEdit && (
+                        {allowEdit && !isCollapsed && (
                             <RoundedButton
                                 hsl={[37, 98, 76]}
                                 size={30}
@@ -81,7 +92,21 @@ function HomeButton(props) {
                         )}
                     </div>
                     <div className="col-12 col-lg-auto">
-                        {allowDelete && (
+                        {allowEdit && (
+                            <RoundedButton
+                                hsl={[197, 43, 52]}
+                                size={30}
+                                className="text-white"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setIsCollapsed((prev) => !prev);
+                                }}
+                                icon={isCollapsed ? 'expand_content' : 'collapse_content'}
+                            />
+                        )}
+                    </div>
+                    <div className="col-12 col-lg-auto">
+                        {allowDelete && !isCollapsed && (
                             <RoundedButton
                                 hsl={[355, 78, 66]}
                                 size={30}

--- a/src/components/ProtocolList.jsx
+++ b/src/components/ProtocolList.jsx
@@ -23,9 +23,6 @@ const ProtocolListStyles = (hue, sat, lig) => {
         }
 
         .button-container {
-            min-height: 7rem;
-            height: 7rem;
-            max-height: 7rem;
             color: #262626;
         }
 

--- a/src/components/ProtocolList.jsx
+++ b/src/components/ProtocolList.jsx
@@ -79,6 +79,8 @@ function ProtocolList(props) {
                     >
                         <HomeButton
                             title={li.title}
+                            primaryDescription={li.primaryDescription}
+                            secondaryDescription={li.secondaryDescription}
                             viewFunction={() => viewFunction(li.id)}
                             allowEdit={allowEdit || li.allowEdit}
                             editFunction={() => editFunction(li.id)}

--- a/src/components/RoundedButton.jsx
+++ b/src/components/RoundedButton.jsx
@@ -36,7 +36,7 @@ const roundedButtonStyles = (hue, sat, lig, size) => {
         }
 
         .btn-${'hsl-' + hue + '-' + sat + '-' + lig}:active {
-            color: #fff !important;
+            color: #fff;
             background-color: hsl(${hue}, ${sat}%, ${+lig * 0.7}%) !important;
             border-color: hsl(${hue}, ${sat}%, ${+lig * 0.7}%);
             box-shadow: inset 0px 4px 4px 0px #00000040;

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -26,7 +26,7 @@ function ScrollToTopButton() {
                 windowScroll > 20 ? 'd-flex' : 'd-none'
             } flex-column justify-content-end align-items-end position-fixed bottom-0 end-0 overflow-hidden w-auto h-auto pb-4 pe-4`}
         >
-            <RoundedButton icon="stat_3" hsl={[197, 43, 52]} onClick={scrollToTop} />
+            <RoundedButton icon="stat_3" hsl={[197, 43, 52]} onClick={scrollToTop} className="text-white" />
         </div>
     );
 }

--- a/src/components/inputs/answers/ImageInput.jsx
+++ b/src/components/inputs/answers/ImageInput.jsx
@@ -100,6 +100,7 @@ function ImageInput(props) {
                     <div className="btn-group dropend">
                         <RoundedButton
                             hsl={[190, 46, 70]}
+                            className="text-white"
                             icon="upload_file"
                             size={41}
                             alt={'Selecionar imagem'}
@@ -157,7 +158,7 @@ function ImageInput(props) {
                                                 />
                                             </div>
                                             <RoundedButton
-                                                className="position-absolute d-inline-block top-0 end-0"
+                                                className="position-absolute d-inline-block text-white top-0 end-0"
                                                 hsl={[190, 46, 70]}
                                                 icon="delete"
                                                 onClick={() => removeImage(i)}
@@ -179,7 +180,7 @@ function ImageInput(props) {
                 </div>
             </div>
             <div className={`${answer.files.length < 3 ? 'd-none' : 'd-flex'} justify-content-end align-items-end w-100 m-0 mt-3 p-0`}>
-                <RoundedButton className="mb-2 me-2" hsl={[190, 46, 70]} icon="visibility" onClick={toggleImageVisibility} />
+                <RoundedButton className="text-white mb-2 me-2" hsl={[190, 46, 70]} icon="visibility" onClick={toggleImageVisibility} />
             </div>
             <input
                 type="file"

--- a/src/components/inputs/answers/LocationInput.jsx
+++ b/src/components/inputs/answers/LocationInput.jsx
@@ -124,10 +124,9 @@ export function Location(props) {
                         <div className="col-auto search-col d-flex justify-content-end m-0 p-0">
                             <RoundedButton
                                 hsl={[190, 46, 70]}
-                                onClick={() => {
-                                    defaultLocation();
-                                }}
+                                onClick={() => defaultLocation()}
                                 icon="add_location"
+                                className="text-white"
                             />
                         </div>
                     </div>

--- a/src/components/inputs/protocol/CreateDependencyInput.jsx
+++ b/src/components/inputs/protocol/CreateDependencyInput.jsx
@@ -95,7 +95,7 @@ function CreateDependencyInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'delete-' + dependency.tempId + '-tooltip'}
                         data-bs-title={'Remover a dependência ' + (isPageDependency ? 'da página.' : 'do grupo.')}
-                        className={'delete-' + dependency.tempId + '-tooltip'}
+                        className={'delete-' + dependency.tempId + '-tooltip text-white'}
                     />
                 </div>
             </div>

--- a/src/components/inputs/protocol/CreateMultipleInputItens.jsx
+++ b/src/components/inputs/protocol/CreateMultipleInputItens.jsx
@@ -165,7 +165,7 @@ function CreateMultipleInputItens(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'move-item-' + item.tempId + '-down-tooltip'}
                         data-bs-title="Mover o item uma posição abaixo na ordem dos itens do grupo."
-                        className={'move-item-' + item.tempId + '-down-tooltip'}
+                        className={'move-item-' + item.tempId + '-down-tooltip text-white'}
                     />
                 </div>
                 <div className="col-auto">
@@ -176,7 +176,7 @@ function CreateMultipleInputItens(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'move-item-' + item.tempId + '-up-tooltip'}
                         data-bs-title="Mover o item uma posição acima na ordem dos itens do grupo."
-                        className={'move-item-' + item.tempId + '-up-tooltip'}
+                        className={'move-item-' + item.tempId + '-up-tooltip text-white'}
                     />
                 </div>
                 {item.type === 'CHECKBOX' && (
@@ -188,7 +188,7 @@ function CreateMultipleInputItens(props) {
                             data-bs-toggle="tooltip"
                             data-bs-custom-class={'add-validation-' + item.tempId + '-tooltip'}
                             data-bs-title="Adicionar uma validação ao item, como mínimo, máximo, dentre outras. O usuário deverá atender a todas as validações para submeter o protocolo."
-                            className={'add-validation-' + item.tempId + '-tooltip'}
+                            className={'add-validation-' + item.tempId + '-tooltip text-white'}
                         />
                     </div>
                 )}
@@ -200,7 +200,7 @@ function CreateMultipleInputItens(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'delete-' + item.tempId + '-tooltip'}
                         data-bs-title="Remover o item do grupo."
-                        className={'delete-' + item.tempId + '-tooltip'}
+                        className={'delete-' + item.tempId + '-tooltip text-white'}
                     />
                 </div>
             </div>
@@ -278,7 +278,7 @@ function CreateMultipleInputItens(props) {
                                 data-bs-toggle="tooltip"
                                 data-bs-custom-class={'upload-image-' + item.tempId + '-tooltip'}
                                 data-bs-title="Adicione imagens ao enunciado da pergunta."
-                                className={'upload-image-' + item.tempId + '-tooltip'}
+                                className={'upload-image-' + item.tempId + '-tooltip text-white'}
                             />
                         </div>
                     </div>
@@ -308,7 +308,7 @@ function CreateMultipleInputItens(props) {
                                                 alt="Imagem selecionada"
                                             />
                                             <RoundedButton
-                                                className="position-absolute top-0 start-100 translate-middle mb-2 me-2"
+                                                className="position-absolute top-0 start-100 translate-middle text-white mb-2 me-2"
                                                 hsl={[190, 46, 70]}
                                                 size={32}
                                                 icon="delete"
@@ -369,6 +369,7 @@ function CreateMultipleInputItens(props) {
                                     <RoundedButton
                                         hsl={[190, 46, 70]}
                                         size={32}
+                                        className="text-white"
                                         icon="keyboard_arrow_down"
                                         onClick={() => updateOptionPlacement(data.placement + 1, data.placement, i)}
                                     />
@@ -377,6 +378,7 @@ function CreateMultipleInputItens(props) {
                                     <RoundedButton
                                         hsl={[190, 46, 70]}
                                         size={32}
+                                        className="text-white"
                                         icon="keyboard_arrow_up"
                                         onClick={() => updateOptionPlacement(data.placement - 1, data.placement, i)}
                                     />
@@ -407,7 +409,7 @@ function CreateMultipleInputItens(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'add-option-' + item.tempId + '-tooltip'}
                         data-bs-title="Adicionar uma nova opção ao item."
-                        className={'bg-steel-blue add-option-' + item.tempId + '-tooltip'}
+                        className={'bg-steel-blue add-option-' + item.tempId + '-tooltip text-white'}
                     />
                 </div>
                 <input

--- a/src/components/inputs/protocol/CreateRangeInput.jsx
+++ b/src/components/inputs/protocol/CreateRangeInput.jsx
@@ -88,7 +88,7 @@ function CreateRangeInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'move-item-' + item.tempId + '-down-tooltip'}
                         data-bs-title="Mover o item uma posição abaixo na ordem dos itens do grupo."
-                        className={'move-item-' + item.tempId + '-down-tooltip'}
+                        className={'move-item-' + item.tempId + '-down-tooltip text-white'}
                     />
                 </div>
                 <div className="col-auto">
@@ -99,7 +99,7 @@ function CreateRangeInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'move-item-' + item.tempId + '-up-tooltip'}
                         data-bs-title="Mover o item uma posição acima na ordem dos itens do grupo."
-                        className={'move-item-' + item.tempId + '-up-tooltip'}
+                        className={'move-item-' + item.tempId + '-up-tooltip text-white'}
                     />
                 </div>
                 <div className="col-auto">
@@ -110,7 +110,7 @@ function CreateRangeInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'delete-' + item.tempId + '-tooltip'}
                         data-bs-title="Remover o item do grupo."
-                        className={'delete-' + item.tempId + '-tooltip'}
+                        className={'delete-' + item.tempId + '-tooltip text-white'}
                     />
                 </div>
             </div>
@@ -188,7 +188,7 @@ function CreateRangeInput(props) {
                                 data-bs-toggle="tooltip"
                                 data-bs-custom-class={'upload-image-' + item.tempId + '-tooltip'}
                                 data-bs-title="Adicione imagens ao enunciado da pergunta."
-                                className={'upload-image-' + item.tempId + '-tooltip'}
+                                className={'upload-image-' + item.tempId + '-tooltip text-white'}
                             />
                         </div>
                     </div>
@@ -218,7 +218,7 @@ function CreateRangeInput(props) {
                                                 alt="Imagem selecionada"
                                             />
                                             <RoundedButton
-                                                className="position-absolute top-0 start-100 translate-middle mb-2 me-2"
+                                                className="position-absolute top-0 start-100 translate-middle text-white mb-2 me-2"
                                                 hsl={[190, 46, 70]}
                                                 size={32}
                                                 icon="delete"

--- a/src/components/inputs/protocol/CreateSubformInput.jsx
+++ b/src/components/inputs/protocol/CreateSubformInput.jsx
@@ -66,8 +66,8 @@ function SubForm(props) {
                     <h1 className="font-century-gothic text-steel-blue fs-3 fw-bold p-0 m-0">Subformulário</h1>
                 </div>
                 <div className="col d-flex justify-content-end p-0">
-                    <RoundedButton hsl={[190, 46, 70]} icon="upload_file" />
-                    <RoundedButton className="ms-2" hsl={[190, 46, 70]} icon="delete" onClick={onInputRemove} />
+                    <RoundedButton className="text-white" hsl={[190, 46, 70]} icon="upload_file" />
+                    <RoundedButton className="text-white ms-2" hsl={[190, 46, 70]} icon="delete" onClick={onInputRemove} />
                 </div>
             </div>
             <div className="row form-check form-switch pb-3 m-0 ms-2">

--- a/src/components/inputs/protocol/CreateTableInput.jsx
+++ b/src/components/inputs/protocol/CreateTableInput.jsx
@@ -65,13 +65,13 @@ function CreateTableInput(props) {
                                     <div className="row justify-content-center">
                                         <span>Adicionar: </span>
                                         <RoundedButton
-                                            className="ms-2"
+                                            className="text-white ms-2"
                                             hsl={[190, 46, 70]}
                                             icon="table_rows"
                                             onClick={() => insertItem('TABLEROW', pageIndex, groupIndex)}
                                         />
                                         <RoundedButton
-                                            className="ms-2"
+                                            className="text-white ms-2"
                                             hsl={[190, 46, 70]}
                                             icon="view_column"
                                             onClick={() => insertTableColumn()}
@@ -92,7 +92,7 @@ function CreateTableInput(props) {
                                                     onChange={(e) => updateTableColumn(columnIndex, e.target.value)}
                                                 />
                                                 <RoundedButton
-                                                    className="ms-2"
+                                                    className="text-white ms-2"
                                                     hsl={[190, 46, 70]}
                                                     size={32}
                                                     icon="delete"
@@ -120,7 +120,7 @@ function CreateTableInput(props) {
                                                     onChange={(event) => changeItem(event, itemIndex)}
                                                 />
                                                 <RoundedButton
-                                                    className="ms-2"
+                                                    className="text-white ms-2"
                                                     hsl={[190, 46, 70]}
                                                     size={32}
                                                     icon="delete"

--- a/src/components/inputs/protocol/CreateTextBoxInput.jsx
+++ b/src/components/inputs/protocol/CreateTextBoxInput.jsx
@@ -114,7 +114,7 @@ function CreateTextBoxInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'move-item-' + item.tempId + '-down-tooltip'}
                         data-bs-title="Mover o item uma posição abaixo na ordem dos itens do grupo."
-                        className={'move-item-' + item.tempId + '-down-tooltip'}
+                        className={'move-item-' + item.tempId + '-down-tooltip text-white'}
                     />
                 </div>
                 <div className="col-auto">
@@ -125,7 +125,7 @@ function CreateTextBoxInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'move-item-' + item.tempId + '-up-tooltip'}
                         data-bs-title="Mover o item uma posição acima na ordem dos itens do grupo."
-                        className={'move-item-' + item.tempId + '-up-tooltip'}
+                        className={'move-item-' + item.tempId + '-up-tooltip text-white'}
                     />
                 </div>
                 <div className="col-auto">
@@ -136,7 +136,7 @@ function CreateTextBoxInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'add-validation-' + item.tempId + '-tooltip'}
                         data-bs-title="Adicionar uma validação ao item, como mínimo, máximo, dentre outras. O usuário deverá atender a todas as validações para submeter o protocolo."
-                        className={'add-validation-' + item.tempId + '-tooltip'}
+                        className={'add-validation-' + item.tempId + '-tooltip text-white'}
                     />
                 </div>
                 <div className="col-auto">
@@ -147,7 +147,7 @@ function CreateTextBoxInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'delete-' + item.tempId + '-tooltip'}
                         data-bs-title="Remover o item do grupo."
-                        className={'delete-' + item.tempId + '-tooltip'}
+                        className={'delete-' + item.tempId + '-tooltip text-white'}
                     />
                 </div>
             </div>
@@ -225,7 +225,7 @@ function CreateTextBoxInput(props) {
                                 data-bs-toggle="tooltip"
                                 data-bs-custom-class={'upload-image-' + item.tempId}
                                 data-bs-title="Adicione imagens ao enunciado da pergunta."
-                                className={'upload-image-' + item.tempId + '-tooltip'}
+                                className={'upload-image-' + item.tempId + '-tooltip text-white'}
                             />
                         </div>
                     </div>
@@ -256,7 +256,7 @@ function CreateTextBoxInput(props) {
                                                 alt="Imagem selecionada"
                                             />
                                             <RoundedButton
-                                                className="position-absolute top-0 start-100 translate-middle mb-2 me-2"
+                                                className="position-absolute top-0 start-100 translate-middle text-white mb-2 me-2"
                                                 hsl={[190, 46, 70]}
                                                 size={32}
                                                 icon="delete"

--- a/src/components/inputs/protocol/CreateValidationInput.jsx
+++ b/src/components/inputs/protocol/CreateValidationInput.jsx
@@ -41,7 +41,7 @@ function CreateValidationInput(props) {
                         data-bs-toggle="tooltip"
                         data-bs-custom-class={'delete-' + validation.tempId + '-tooltip'}
                         data-bs-title="Remover a validação do item."
-                        className={'delete-' + validation.tempId + '-tooltip'}
+                        className={'delete-' + validation.tempId + '-tooltip text-white'}
                     />
                 </div>
             </div>

--- a/src/pages/ApplicationAnswersPage.jsx
+++ b/src/pages/ApplicationAnswersPage.jsx
@@ -403,6 +403,7 @@ function AnswerPage(props) {
                                                         <div className="col-auto">
                                                             <RoundedButton
                                                                 hsl={[97, 43, 70]}
+                                                                className="text-white"
                                                                 size={24}
                                                                 onClick={() => approveAnswer(key)}
                                                                 icon="check"

--- a/src/pages/ApplicationsPage.jsx
+++ b/src/pages/ApplicationsPage.jsx
@@ -147,7 +147,14 @@ function ApplicationsPage(props) {
                                             <ProtocolList
                                                 listItems={visibleApplications
                                                     .filter((a) => a.applier.id === user.id)
-                                                    .map((a) => ({ id: a.id, title: a.protocol.title }))}
+                                                    .map((a) => ({
+                                                        id: a.id,
+                                                        title: a.protocol.title,
+                                                        primaryDescription: `${a.applier?.username}`,
+                                                        secondaryDescription: `#${a.id} - ${new Date(a.createdAt).toLocaleDateString(
+                                                            'pt-BR'
+                                                        )}`,
+                                                    }))}
                                                 hsl={[36, 98, 83]}
                                                 allowEdit={true}
                                                 allowDelete={true}
@@ -167,6 +174,8 @@ function ApplicationsPage(props) {
                                                 title: a.protocol.title,
                                                 allowEdit: a.actions.toUpdate,
                                                 allowDelete: a.actions.toDelete,
+                                                primaryDescription: `${a.applier?.username}`,
+                                                secondaryDescription: `#${a.id} - ${new Date(a.createdAt).toLocaleDateString('pt-BR')}`,
                                             }))}
                                             hsl={[16, 100, 88]}
                                             viewFunction={(id) => navigate(`${id}`)}

--- a/src/pages/CreateApplicationPage.jsx
+++ b/src/pages/CreateApplicationPage.jsx
@@ -616,6 +616,7 @@ function CreateApplicationPage(props) {
                                                 <div className="col-auto">
                                                     <RoundedButton
                                                         hsl={[197, 43, 52]}
+                                                        className="text-white"
                                                         onClick={() => searchUsers(VUSearchInput)}
                                                         icon="person_search"
                                                     />
@@ -690,6 +691,7 @@ function CreateApplicationPage(props) {
                                                 <div className="col-auto">
                                                     <RoundedButton
                                                         hsl={[197, 43, 52]}
+                                                        className="text-white"
                                                         onClick={() => searchClassrooms(VCSearchInput)}
                                                         icon="search"
                                                     />
@@ -783,6 +785,7 @@ function CreateApplicationPage(props) {
                                                 <div className="col-auto">
                                                     <RoundedButton
                                                         hsl={[197, 43, 52]}
+                                                        className="text-white"
                                                         onClick={() => searchAnswerUsers(AVUSearchInput)}
                                                         icon="person_search"
                                                     />
@@ -857,6 +860,7 @@ function CreateApplicationPage(props) {
                                                 <div className="col-auto">
                                                     <RoundedButton
                                                         hsl={[197, 43, 52]}
+                                                        className="text-white"
                                                         onClick={() => searchAnswerClassrooms(AVCSearchInput)}
                                                         icon="search"
                                                     />

--- a/src/pages/CreateClassroomPage.jsx
+++ b/src/pages/CreateClassroomPage.jsx
@@ -381,6 +381,7 @@ function CreateClassroomPage(props) {
                                             <div className="col-auto">
                                                 <RoundedButton
                                                     hsl={[197, 43, 52]}
+                                                    className="text-white"
                                                     onClick={() => {
                                                         String(userSearchTerm).length >= 3
                                                             ? searchUsers(userSearchTerm)

--- a/src/pages/CreateUserPage.jsx
+++ b/src/pages/CreateUserPage.jsx
@@ -415,12 +415,18 @@ function CreateUserPage(props) {
                                                 <div className="col-auto">
                                                     <RoundedButton
                                                         hsl={[197, 43, 52]}
+                                                        className="text-white"
                                                         icon="visibility"
                                                         onClick={() => setPasswordVisibility((prev) => !prev)}
                                                     />
                                                 </div>
                                                 <div className="col-auto">
-                                                    <RoundedButton hsl={[197, 43, 52]} icon="shuffle" onClick={generateRandomHash} />
+                                                    <RoundedButton
+                                                        hsl={[197, 43, 52]}
+                                                        className="text-white"
+                                                        icon="shuffle"
+                                                        onClick={generateRandomHash}
+                                                    />
                                                 </div>
                                             </div>
                                         </div>
@@ -506,6 +512,7 @@ function CreateUserPage(props) {
                                                         <div className="col-auto">
                                                             <RoundedButton
                                                                 hsl={[197, 43, 52]}
+                                                                className="text-white"
                                                                 onClick={() => {
                                                                     String(classroomSearchTerm).length >= 3
                                                                         ? searchClassrooms(classroomSearchTerm)

--- a/src/pages/InstitutionPage.jsx
+++ b/src/pages/InstitutionPage.jsx
@@ -165,7 +165,7 @@ function InstitutionPage(props) {
                                             </div>
                                             <div className="col-auto">
                                                 <Link to={'users/create'} className="text-decoration-none">
-                                                    <RoundedButton hsl={[197, 43, 52]} icon="person_add" />
+                                                    <RoundedButton hsl={[197, 43, 52]} className="text-white" icon="person_add" />
                                                 </Link>
                                             </div>
                                         </div>
@@ -215,7 +215,7 @@ function InstitutionPage(props) {
                                             </div>
                                             <div className="col-auto">
                                                 <Link to={'classrooms/create'} className="text-decoration-none">
-                                                    <RoundedButton hsl={[197, 43, 52]} icon="group_add" />
+                                                    <RoundedButton hsl={[197, 43, 52]} className="text-white" icon="group_add" />
                                                 </Link>
                                             </div>
                                         </div>

--- a/src/pages/InstitutionsPage.jsx
+++ b/src/pages/InstitutionsPage.jsx
@@ -137,6 +137,7 @@ function InstitutionsPage(props) {
                                             title: i.name,
                                             allowEdit: i.actions.toUpdate,
                                             allowDelete: i.actions.toDelete,
+                                            primaryDescription: `${i.address.city} - ${i.address.state}`,
                                         }))}
                                         hsl={[36, 98, 83]}
                                         viewFunction={(id) => navigate(`${id}`)}

--- a/src/pages/ProtocolsPage.jsx
+++ b/src/pages/ProtocolsPage.jsx
@@ -140,13 +140,17 @@ function ProtocolsPage(props) {
                                     <div className="col-12 col-lg-6 d-flex flex-column m-vh-80 h-lg-100">
                                         <h1 className="color-grey font-century-gothic text-nowrap fw-bold fs-3 mb-4">Meus protocolos</h1>
                                         <ProtocolList
-                                            listItems={visibleProtocols.map((p) => ({
-                                                id: p.id,
-                                                title: p.title,
-                                                allowEdit: p.actions.toUpdate,
-                                                allowDelete: p.actions.toDelete,
-                                            }))}
-                                            hsl={[16, 100, 88]}
+                                            listItems={visibleProtocols
+                                                .filter((p) => p.creator.id === user.id)
+                                                .map((p) => ({
+                                                    id: p.id,
+                                                    title: p.title,
+                                                    allowEdit: p.actions.toUpdate,
+                                                    allowDelete: p.actions.toDelete,
+                                                    primaryDescription: `${p.creator?.username}`,
+                                                    secondaryDescription: `#${p.id} - ${new Date(p.createdAt).toLocaleDateString('pt-BR')}`,
+                                                }))}
+                                            hsl={[36, 98, 83]}
                                             viewFunction={(id) => navigate(`${id}`)}
                                             editFunction={(id) => navigate(`${id}/manage`)}
                                             deleteFunction={(id) => deleteProtocol(id)}
@@ -160,7 +164,14 @@ function ProtocolsPage(props) {
                                 >
                                     <h1 className="color-grey font-century-gothic text-nowrap fw-bold fs-3 mb-4">Protocolos disponíveis</h1>
                                     <ProtocolList
-                                        listItems={visibleProtocols.map((p) => ({ id: p.id, title: p.title }))}
+                                        listItems={visibleProtocols.map((p) => ({
+                                            id: p.id,
+                                            title: p.title,
+                                            allowEdit: p.actions.toUpdate,
+                                            allowDelete: p.actions.toDelete,
+                                            primaryDescription: `${p.creator?.username}`,
+                                            secondaryDescription: `#${p.id} - ${new Date(p.createdAt).toLocaleDateString('pt-BR')}`,
+                                        }))}
                                         hsl={[16, 100, 88]}
                                         viewFunction={(id) => navigate(`${id}`)}
                                     />


### PR DESCRIPTION
As funções aqui apresentadas tem por objetivo apresentar dados relevantes dos protocolos, aplicações e instituições presentes no sistema em listas nas quais os mesmos aparecem. Além disso, foram realizadas correções visando aprimorar a modularidade e aparência de botões.

### Dados adicionais e opção de expansão em listas de protocolos
* Os botões/links presentes nas listas de protocolo, além do título, agora apresentam informações relevantes para os mesmos: criador, data e id no caso de protocolos e aplicações [[1]](diffhunk://#diff-916eef37efa9e8ed763477376594b83ffd4da6fe1be638e549c95ee2e918bfaeR177-R178); cidade e estado no caso de instituições [[2]](diffhunk://#diff-9d4e7b3351fb92537bcf0e6c010bacf2aeaffb4ef828ae1b31661c0a7b5553c2R140). Tais informações são passadas via duas novas propriedades `primaryDescription` e `secondaryDescription` [[3]](diffhunk://#diff-fce0bc8731e01df17ebf6cd4141dca5861d5a88ed218e22c9e45fa872ec1a8ccR55-R56). Para permitir tal adição, os textos foram reduzidos e reestilizados;
* Os links passam também a contar com um botão para expandir e colapsar, permitindo que todo o conteúdo neles contidos seja visualizado integralmente sem necessidade de rolagem [[4]](diffhunk://#diff-fce0bc8731e01df17ebf6cd4141dca5861d5a88ed218e22c9e45fa872ec1a8ccR78-R128). Os botões também foram reestilizados para se apresentarem verticalmente em telas menores, visando otimização e preenchimento de espaço;

### Correção em botões redondos
* Visando modularidade, uma propriedade fixa de botões redondos, a cor branca, foi removida em prol de uma definição própria de cada instância do mesmo [[5]](diffhunk://#diff-960af39c48728e5e9c1e966989b9cfb2c08217d97bcc7d3aaf3d40ab146f8a30L39-R39) [[6]](diffhunk://#diff-54426d44ae72e9c57c6e44c47d7bcf9f6da0ffe0fdf443f4525f5968247a5451L79-R79);
