### PR TITLE
#543 [FIX]: Remoção de propriedades fora do formato esperado pela API em requisições

### DIFF
--- a/src/pages/CreateApplicationPage.jsx
+++ b/src/pages/CreateApplicationPage.jsx
@@ -244,7 +244,7 @@ function CreateApplicationPage(props) {
 
     const submitApplication = (e) => {
         e.preventDefault();
-        const formData = serialize(application, { indices: true });
+        const formData = serialize({ ...application, actions: undefined }, { indices: true });
         if (isEditing) {
             axios
                 .put(`${process.env.REACT_APP_API_URL}api/application/updateApplication/${applicationId}`, formData, {

--- a/src/pages/CreateClassroomPage.jsx
+++ b/src/pages/CreateClassroomPage.jsx
@@ -220,7 +220,7 @@ function CreateClassroomPage(props) {
 
     const submitClassroom = (e) => {
         e.preventDefault();
-        const formData = serialize(classroom, { indices: true });
+        const formData = serialize({ ...classroom, actions: undefined }, { indices: true });
         if (classroom.users.length >= 2) {
             if (isEditing) {
                 axios

--- a/src/pages/CreateInstitutionPage.jsx
+++ b/src/pages/CreateInstitutionPage.jsx
@@ -143,7 +143,7 @@ function CreateInstitutionPage(props) {
 
     const submitInstitution = (e) => {
         e.preventDefault();
-        const formData = serialize(institution, { indices: true });
+        const formData = serialize({ ...institution, actions: undefined }, { indices: true });
         if (isEditing) {
             axios
                 .put(`${process.env.REACT_APP_API_URL}api/institution/updateInstitution/${institutionId}`, formData, {

--- a/src/pages/CreateProtocolPage.jsx
+++ b/src/pages/CreateProtocolPage.jsx
@@ -289,9 +289,16 @@ function CreateProtocolPage(props) {
     const handleSubmit = (event) => {
         event.preventDefault();
 
-        const placedProtocol = { ...protocol, creatorId: user.id, owners: [] };
+        const processedProtocol = {
+            ...protocol,
+            creatorId: isEditing ? undefined : user.id,
+            pages: protocol.pages.map(({ tempId, ...rest }) => ({
+                ...rest,
+                itemGroups: rest.itemGroups.map(({ tempId, ...rest }) => rest),
+            })),
+        };
 
-        const formData = serialize(placedProtocol, { indices: true });
+        const formData = serialize(processedProtocol, { indices: true });
 
         if (isEditing) {
             axios

--- a/src/pages/CreateUserPage.jsx
+++ b/src/pages/CreateUserPage.jsx
@@ -236,7 +236,10 @@ function CreateUserPage(props) {
     const submitNewUser = (e) => {
         e.preventDefault();
         const salt = process.env.REACT_APP_SALT;
-        const formData = newUser.hash ? serialize({ ...newUser, hash: hashSync(newUser.hash, salt) }) : serialize({ ...newUser });
+        const processedUser = { ...newUser, actions: undefined, hashValidation: undefined, profileImage: undefined };
+        const formData = newUser.hash
+            ? serialize({ ...processedUser, hash: hashSync(processedUser.hash, salt) })
+            : serialize({ ...processedUser });
         if (isEditing) {
             axios
                 .put(`${process.env.REACT_APP_API_URL}api/user/updateUser/${userId || user.id}`, formData, {


### PR DESCRIPTION
Esta solicitação de pull inclui alterações na serialização de dados de formulário em várias páginas para garantir que campos desnecessários (e rejeitados pela API) sejam excluídos antes de enviar os dados ao servidor. As alterações mais importantes incluem modificações nos componentes `CreateApplicationPage`, `CreateClassroomPage`, `CreateInstitutionPage`, `CreateProtocolPage` e `CreateUserPage`.

Alterações na serialização de dados de formulário:

* [`src/pages/CreateApplicationPage.jsx`](diffhunk://#diff-9172200bd2b0fff6561146a56be00c2cbf2a3edfeb1d4c1277387f7524e2f3b3L247-R247): A função `submitApplication` foi atualizada para excluir o campo `actions` dos dados de formulário serializados.
* [`src/pages/CreateClassroomPage.jsx`](diffhunk://#diff-62edc542855f65bb6df3f6b84a6581152a1a32ed43595d47ad522bbcca2d1e8dL223-R223): A função `submitClassroom` foi atualizada para excluir o campo `actions` dos dados serializados do formulário.
* [`src/pages/CreateInstitutionPage.jsx`](diffhunk://#diff-9c6e4694178dc58a8d2bb4a5f474c8410ba309de69d7d4013e74ed74fa07b5c4L146-R146): A função `submitInstitution` foi atualizada para excluir o campo `actions` dos dados do formulário serializado.
* [`src/pages/CreateProtocolPage.jsx`](diffhunk://#diff-1e8174beeaad5060ad031a8f01f3a66d647d6a7ea2de1be6ff662576796ebd58L292-R301): Modificou a função `handleSubmit` para excluir o campo `creatorId` ao editar e remover `tempId` de objetos aninhados antes da serialização.
* [`src/pages/CreateUserPage.jsx`](diffhunk://#diff-9756ba23cf6bb9835c1472e7741d14b9f8d1462023090eca42f8e70c1534c19fL239-R242): A função `submitNewUser` foi atualizada para excluir os campos `actions`, `hashValidation` e `profileImage` dos dados serializados do formulário.