### PR TITLE
#564 [FIX]: altera a estrutura do layout em ApplicationPage e ProtocolPage para melhor capacidade de resposta

### DIFF
--- a/src/pages/ApplicationPage.jsx
+++ b/src/pages/ApplicationPage.jsx
@@ -340,13 +340,13 @@ function ApplicationPage(props) {
 
     return (
         <div className="d-flex flex-column flex-grow-1 w-100 min-vh-100">
-            <div className="row flex-grow-1 m-0">
-                <div className="col-auto bg-coral-red d-flex position-lg-sticky vh-100 top-0 p-0">
+            <div className="d-flex flex-grow-1 w-100">
+                <div className="d-flex flex-column position-lg-sticky bg-coral-red vh-100 top-0 p-0">
                     <div className="offcanvas-lg offcanvas-start bg-coral-red w-auto d-flex" tabIndex="-1" id="sidebar">
                         <Sidebar showExitButton={false} />
                     </div>
                 </div>
-                <div className="col d-flex flex-column flex-grow-1 bg-yellow-orange p-0">
+                <div className="d-flex flex-column flex-grow-1 overflow-hidden bg-yellow-orange p-0">
                     <NavBar showNavTogglerMobile={true} showNavTogglerDesktop={false} />
 
                     <div className="row d-flex align-items-center justify-content-center h-100 p-0 m-0">

--- a/src/pages/ProtocolPage.jsx
+++ b/src/pages/ProtocolPage.jsx
@@ -114,13 +114,13 @@ function ProtocolPage(props) {
 
     return (
         <div className="d-flex flex-column flex-grow-1 w-100 min-vh-100">
-            <div className="row flex-grow-1 flex-nowrap m-0">
-                <div className="col-auto bg-coral-red d-flex position-lg-sticky vh-100 top-0 p-0">
+            <div className="d-flex flex-grow-1 w-100">
+                <div className="d-flex flex-column position-lg-sticky bg-coral-red vh-100 top-0 p-0">
                     <div className="offcanvas-lg offcanvas-start bg-coral-red w-auto d-flex" tabIndex="-1" id="sidebar">
                         <Sidebar showExitButton={false} />
                     </div>
                 </div>
-                <div className="col d-flex flex-column flex-grow-1 bg-yellow-orange p-0">
+                <div className="d-flex flex-column flex-grow-1 overflow-hidden bg-yellow-orange p-0">
                     <NavBar showNavTogglerMobile={true} showNavTogglerDesktop={false} />
 
                     <div className="row d-flex align-items-center justify-content-center h-100 p-0 m-0">


### PR DESCRIPTION
- Zera o scroll horizontal quando o conteúdo interno da div principal é extenso horizontalmente.
- Sem quebra de layout.
- Menos dependência do sistema de grid do bootstrap, o que nesse caso me parece razoável.

Mudanças:

* [`src/pages/ApplicationPage.jsx`](diffhunk://#diff-0a3dda114ca63d20c5e8d66398298e384e7073cf184b28d84cf31fd0a3a6acaeL343-R349): alterações na estrutura para usar as classes `d-flex` e `flex-column` para maior flexibilidade e responsividade. Essa alteração garante que a barra lateral e as áreas de conteúdo principal sejam mais adaptáveis ​​a diferentes tamanhos de tela.
* [`src/pages/ProtocolPage.jsx`](diffhunk://#diff-57872b24029dfbca9f19e722cd3f8fbc05e6dcbbb20214a072044423e92392d5L117-R123): Modificações semelhantes foram feitas neste arquivo para se alinhar às alterações em `ApplicationPage.jsx`, garantindo uma abordagem de layout consistente em ambas as páginas.