### PR TITLE
#576 [FIX]: Obtenção dos dados de protocolos e aplicações gerenciadas

### DIFF
--- a/src/pages/ApplicationsPage.jsx
+++ b/src/pages/ApplicationsPage.jsx
@@ -68,6 +68,7 @@ function ApplicationsPage(props) {
     const { user, logout } = useContext(AuthContext);
 
     const [visibleApplications, setVisibleApplications] = useState([]);
+    const [managedApplications, setManagedApplications] = useState([]);
     const { localApplications, connected, clearLocalApplications } = useContext(StorageContext);
 
     const navigate = useNavigate();
@@ -78,6 +79,7 @@ function ApplicationsPage(props) {
         if (!connected) {
             if (localApplications !== undefined) {
                 setVisibleApplications(localApplications);
+                setManagedApplications(localApplications.filter((a) => a.applier.id === user.id));
                 setIsLoading(false);
             }
         } else if (isLoading && user.status !== 'loading') {
@@ -92,8 +94,19 @@ function ApplicationsPage(props) {
                 .catch((error) =>
                     setError({ text: 'Erro ao obter informações de aplicações', description: error.response?.data.message || '' })
                 );
+            axios
+                .get(process.env.REACT_APP_API_URL + `api/application/getMyApplications`, {
+                    headers: { 'Content-Type': 'multipart/form-data', Authorization: `Bearer ${user.token}` },
+                })
+                .then((response) => {
+                    setManagedApplications(response.data.data);
+                    setIsLoading(false);
+                })
+                .catch((error) =>
+                    setError({ text: 'Erro ao obter informações de aplicações', description: error.response?.data.message || '' })
+                );
         }
-    }, [user.token, logout, navigate, connected, localApplications, isDashboard, isLoading, user.status]);
+    }, [user.token, logout, navigate, connected, localApplications, isDashboard, isLoading, user.status, user.id]);
 
     const deleteApplication = (applicationId) => {
         axios
@@ -139,18 +152,14 @@ function ApplicationsPage(props) {
                                                 Minhas aplicações
                                             </h1>
                                             <ProtocolList
-                                                listItems={visibleApplications
-                                                    .filter((a) => a.applier.id === user.id)
-                                                    .map((a) => ({
-                                                        id: a.id,
-                                                        title: a.protocol.title,
-                                                        primaryDescription: `${a.applier?.username}`,
-                                                        secondaryDescription: `#${a.id} - ${new Date(a.createdAt).toLocaleDateString(
-                                                            'pt-BR'
-                                                        )}`,
-                                                        allowEdit: a.actions.toUpdate,
-                                                        allowDelete: a.actions.toDelete,
-                                                    }))}
+                                                listItems={managedApplications.map((a) => ({
+                                                    id: a.id,
+                                                    title: a.protocol.title,
+                                                    primaryDescription: `${a.applier?.username}`,
+                                                    secondaryDescription: `#${a.id} - ${new Date(a.createdAt).toLocaleDateString('pt-BR')}`,
+                                                    allowEdit: a.actions.toUpdate,
+                                                    allowDelete: a.actions.toDelete,
+                                                }))}
                                                 hsl={[36, 98, 83]}
                                                 viewFunction={(id) => navigate(`${id}`)}
                                                 editFunction={(id) => navigate(`${id}/manage`)}

--- a/src/pages/ProtocolsPage.jsx
+++ b/src/pages/ProtocolsPage.jsx
@@ -66,6 +66,7 @@ function ProtocolsPage(props) {
 
     const { clearLocalApplications } = useContext(StorageContext);
     const [visibleProtocols, setVisibleProtocols] = useState([]);
+    const [managedProtocols, setManagedProtocols] = useState([]);
 
     const navigate = useNavigate();
     const { isDashboard } = useContext(LayoutContext);
@@ -80,6 +81,17 @@ function ProtocolsPage(props) {
                 })
                 .then((response) => {
                     setVisibleProtocols(response.data.data);
+                    setIsLoading(false);
+                })
+                .catch((error) =>
+                    setError({ text: 'Erro ao obter informações de protocolos', description: error.response?.data.message || '' })
+                );
+            axios
+                .get(process.env.REACT_APP_API_URL + `api/protocol/getMyProtocols`, {
+                    headers: { 'Content-Type': 'multipart/form-data', Authorization: `Bearer ${user.token}` },
+                })
+                .then((response) => {
+                    setManagedProtocols(response.data.data);
                     setIsLoading(false);
                 })
                 .catch((error) =>
@@ -129,16 +141,14 @@ function ProtocolsPage(props) {
                                     <div className="col-12 col-lg d-flex flex-column m-vh-80 h-lg-100">
                                         <h1 className="color-grey font-century-gothic text-nowrap fw-bold fs-3 mb-4">Meus protocolos</h1>
                                         <ProtocolList
-                                            listItems={visibleProtocols
-                                                .filter((p) => p.creator.id === user.id)
-                                                .map((p) => ({
-                                                    id: p.id,
-                                                    title: p.title,
-                                                    allowEdit: p.actions.toUpdate,
-                                                    allowDelete: p.actions.toDelete,
-                                                    primaryDescription: `${p.creator?.username}`,
-                                                    secondaryDescription: `#${p.id} - ${new Date(p.createdAt).toLocaleDateString('pt-BR')}`,
-                                                }))}
+                                            listItems={managedProtocols.map((p) => ({
+                                                id: p.id,
+                                                title: p.title,
+                                                allowEdit: p.actions.toUpdate,
+                                                allowDelete: p.actions.toDelete,
+                                                primaryDescription: `${p.creator?.username}`,
+                                                secondaryDescription: `#${p.id} - ${new Date(p.createdAt).toLocaleDateString('pt-BR')}`,
+                                            }))}
                                             hsl={[36, 98, 83]}
                                             viewFunction={(id) => navigate(`${id}`)}
                                             editFunction={(id) => navigate(`${id}/manage`)}


### PR DESCRIPTION
Este pull request introduz aprimoramentos nos componentes `ApplicationsPage` e `ProtocolsPage` ao adicionar gerenciamento de estado separado para dados específicos do usuário (`managedApplications` e `managedProtocols`). 
As alterações visam consistência com a estrutura da API, que fornece endpoints distintos para a obtenção das entidades visíveis e específicas. Como não é transparente (nem papel do front) garantir que um conjunto é subconjunto do outro, convém obtê-los conforme a API.

A abordagem antiga, de obter as aplicações gerenciadas filtrando as aplicações visíveis, foi mantida para os dados offline, para não estrapolar o escopo da issue. Deve, no entanto, ser considerada defasada e com correção pendente (apesar de funcionar, já que, no fim das contas, um conjunto realmente é subconjunto do outro).

### Alterações na `ApplicationsPage`:

* Introduziu uma nova variável de estado `managedApplications` para armazenar aplicativos específicos do usuário conectado.
* Adição de uma nova chamada de API para buscar aplicativos específicos do usuário (`/api/application/getMyApplications`) e preencher `managedApplications`.
* Atualização do componente `ProtocolList` para usar `managedApplications` diretamente em vez de filtrar `visibleApplications`.

### Alterações na `ProtocolsPage`:

* Introduziu uma nova variável de estado `managedProtocols` para armazenar protocolos específicos do usuário conectado.
* Adicionada uma nova chamada de API para buscar protocolos específicos do usuário (`/api/protocol/getMyProtocols`) e preencher `managedProtocols`.
* Atualização do componente `ProtocolList` para usar `managedProtocols` diretamente em vez de filtrar `visibleProtocols`.